### PR TITLE
feat: add countdown web app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.env
+

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      run: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Countdown Web
+
+React + TypeScript の静的サイトです。月末、四半期末、半期末、年度末までのカウントダウンを表示します。土日と日本の祝日を除いた営業日の残り日数も表示します。日付計算には Temporal API（@js-temporal/polyfill）を利用しています。
+
+## 開発
+
+```sh
+npm install
+npm run dev
+```
+
+## ビルド
+
+```sh
+npm run build
+```
+
+## デプロイ
+
+GitHub Pages にデプロイする場合は GitHub Actions の `Deploy` ワークフローを利用するか、以下のコマンドで `gh-pages` ブランチへデプロイできます。
+
+```sh
+npm run deploy
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import eslint from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    ignores: ['node_modules', 'dist'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      react: reactPlugin,
+      'react-hooks': reactHooks,
+    },
+    settings: { react: { version: 'detect' } },
+    rules: {
+      ...eslint.configs.recommended.rules,
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      ...tseslint.configs.recommended.rules,
+    },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Countdown</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "countdown-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "deploy": "gh-pages -d dist"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "date-holidays": "^3.20.0",
+    "@js-temporal/polyfill": "^0.4.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "@eslint/js": "^9.4.0",
+    "eslint": "^9.4.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "gh-pages": "^6.0.0",
+    "lefthook": "^1.4.3",
+    "typescript": "^5.1.6",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { Temporal } from '@js-temporal/polyfill';
+import Holidays from 'date-holidays';
+
+const tz = 'Asia/Tokyo';
+const hd = new Holidays('JP');
+
+function endOfMonth(now: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+  return now
+    .with({ day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 })
+    .add({ months: 1 })
+    .subtract({ nanoseconds: 1 });
+}
+
+function endOfQuarter(now: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+  const q = Math.floor((now.month - 1) / 3);
+  const startNextQuarterMonth = q * 3 + 4;
+  const year = startNextQuarterMonth > 12 ? now.year + 1 : now.year;
+  const month = ((startNextQuarterMonth - 1) % 12) + 1;
+  return now
+    .with({ year, month, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 })
+    .subtract({ nanoseconds: 1 });
+}
+
+function endOfHalfYear(now: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+  const startNextHalf = now.month <= 6 ? 7 : 13;
+  const year = startNextHalf > 12 ? now.year + 1 : now.year;
+  const month = ((startNextHalf - 1) % 12) + 1;
+  return now
+    .with({ year, month, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 })
+    .subtract({ nanoseconds: 1 });
+}
+
+function endOfFiscalYear(now: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+  const year = now.month <= 3 ? now.year : now.year + 1;
+  return Temporal.ZonedDateTime.from({
+    timeZone: tz,
+    year,
+    month: 4,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0,
+    microsecond: 0,
+    nanosecond: 0,
+  }).subtract({ nanoseconds: 1 });
+}
+
+function businessDaysBetween(start: Temporal.PlainDate, end: Temporal.PlainDate): number {
+  let current = start.add({ days: 1 });
+  let count = 0;
+  while (Temporal.PlainDate.compare(current, end) <= 0) {
+    const day = current.dayOfWeek; // 1=Mon .. 7=Sun
+    const isWeekend = day === 6 || day === 7;
+    const jsDate = new Date(Date.UTC(current.year, current.month - 1, current.day));
+    const isHoliday = hd.isHoliday(jsDate) !== false;
+    if (!isWeekend && !isHoliday) {
+      count += 1;
+    }
+    current = current.add({ days: 1 });
+  }
+  return count;
+}
+
+function formatDuration(seconds: number): string {
+  const s = Math.max(seconds, 0);
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  return `${days}日 ${hours}時間 ${minutes}分 ${secs}秒`;
+}
+
+export default function App() {
+  const [now, setNow] = useState(Temporal.Now.zonedDateTimeISO(tz));
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Temporal.Now.zonedDateTimeISO(tz)), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const targets = [
+    { label: '月末', date: endOfMonth(now) },
+    { label: '四半期末', date: endOfQuarter(now) },
+    { label: '半期末', date: endOfHalfYear(now) },
+    { label: '年度末', date: endOfFiscalYear(now) },
+  ];
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>カウントダウン</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>対象</th>
+            <th>残り時間</th>
+            <th>営業日</th>
+          </tr>
+        </thead>
+        <tbody>
+          {targets.map((t) => {
+            const seconds = Math.floor(t.date.epochSeconds - now.epochSeconds);
+            const business = businessDaysBetween(now.toPlainDate(), t.date.toPlainDate());
+            return (
+              <tr key={t.label}>
+                <td>{t.label} ({new Date(t.date.epochMilliseconds).toLocaleDateString('ja-JP')})</td>
+                <td>{formatDuration(seconds)}</td>
+                <td>{business}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+});


### PR DESCRIPTION
## Summary
- use Temporal API for countdown and business-day calculations
- upgrade ESLint to v9 with flat config and remove legacy config
- document Temporal usage and add polyfill dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a4775c1458832e9798ea4141493fe7