### PR TITLE
chore: upgrade tailwindcss to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gh-pages": "^6.0.0",
     "lefthook": "^1.4.3",
     "postcss": "^8.4.41",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "^4.0.0",
     "typescript": "^5.1.6",
     "vite": "^7.1.3"
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
## Summary
- upgrade Tailwind CSS dependency to the latest v4 release
- adjust CSS entry to use new `@import "tailwindcss"` syntax

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Unknown word "use strict" from Tailwind 3 when using new import)*

------
https://chatgpt.com/codex/tasks/task_e_68a48fb0c500832eb4ed68e68f0aced9