### PR TITLE
Add simple date-only display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ https://szk0u.github.io/countdown-web/
 
 React + TypeScript の静的サイトです。月末、四半期末、半期末、年度末までのカウントダウンを表示します。土日と日本の祝日を除いた営業日の残り日数も表示します。日付計算には Temporal API（@js-temporal/polyfill）を利用しています。
 
+シンプルモードでは日付のみを表示できます。
+
 ## 開発
 
 ```sh

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ export default function App() {
   const [dark, setDark] = useState(() =>
     window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
   );
+  const [simple, setSimple] = useState(false);
 
   useEffect(() => {
     const timer = setInterval(() => setNow(Temporal.Now.zonedDateTimeISO(tz)), 1000);
@@ -121,9 +122,9 @@ export default function App() {
                 カウントダウン
               </h1>
               <p className="text-slate-600 dark:text-slate-400 mt-1">
-                {now.toLocaleString('ja-JP', { 
-                  year: 'numeric', 
-                  month: 'long', 
+                {now.toLocaleString('ja-JP', {
+                  year: 'numeric',
+                  month: 'long',
                   day: 'numeric',
                   hour: '2-digit',
                   minute: '2-digit'
@@ -131,16 +132,28 @@ export default function App() {
               </p>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => setDark((d) => !d)}
-            className="group relative px-6 py-3 bg-white/20 dark:bg-slate-800/50 backdrop-blur-sm border border-white/30 dark:border-slate-700/50 rounded-2xl hover:bg-white/30 dark:hover:bg-slate-800/70 transition-all duration-300 shadow-lg hover:shadow-xl"
-          >
-            <div className="flex items-center gap-2 text-slate-700 dark:text-slate-300">
-              <span className="text-lg">{dark ? '☀️' : '🌙'}</span>
-              <span className="font-medium">{dark ? 'ライト' : 'ダーク'}</span>
-            </div>
-          </button>
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={() => setDark((d) => !d)}
+              className="group relative px-6 py-3 bg-white/20 dark:bg-slate-800/50 backdrop-blur-sm border border-white/30 dark:border-slate-700/50 rounded-2xl hover:bg-white/30 dark:hover:bg-slate-800/70 transition-all duration-300 shadow-lg hover:shadow-xl"
+            >
+              <div className="flex items-center gap-2 text-slate-700 dark:text-slate-300">
+                <span className="text-lg">{dark ? '☀️' : '🌙'}</span>
+                <span className="font-medium">{dark ? 'ライト' : 'ダーク'}</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setSimple((s) => !s)}
+              className="group relative px-6 py-3 bg-white/20 dark:bg-slate-800/50 backdrop-blur-sm border border-white/30 dark:border-slate-700/50 rounded-2xl hover:bg-white/30 dark:hover:bg-slate-800/70 transition-all duration-300 shadow-lg hover:shadow-xl"
+            >
+              <div className="flex items-center gap-2 text-slate-700 dark:text-slate-300">
+                <span className="text-lg">{simple ? '🔢' : '📅'}</span>
+                <span className="font-medium">{simple ? '詳細' : 'シンプル'}</span>
+              </div>
+            </button>
+          </div>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -184,36 +197,38 @@ export default function App() {
                     </div>
                   </div>
                   
-                  <div className="space-y-4">
-                    <div className="grid grid-cols-4 gap-2">
-                      <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
-                        <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{days}</div>
-                        <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">日</div>
+                  {!simple && (
+                    <div className="space-y-4">
+                      <div className="grid grid-cols-4 gap-2">
+                        <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
+                          <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{days}</div>
+                          <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">日</div>
+                        </div>
+                        <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
+                          <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{hours}</div>
+                          <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">時間</div>
+                        </div>
+                        <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
+                          <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{minutes}</div>
+                          <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">分</div>
+                        </div>
+                        <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
+                          <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{secs}</div>
+                          <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">秒</div>
+                        </div>
                       </div>
-                      <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
-                        <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{hours}</div>
-                        <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">時間</div>
-                      </div>
-                      <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
-                        <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{minutes}</div>
-                        <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">分</div>
-                      </div>
-                      <div className="text-center p-3 bg-slate-50 dark:bg-slate-700/50 rounded-xl">
-                        <div className="text-2xl font-bold text-slate-800 dark:text-slate-200">{secs}</div>
-                        <div className="text-xs text-slate-600 dark:text-slate-400 font-medium">秒</div>
+
+                      <div className="flex items-center justify-between p-4 bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-700/30 dark:to-slate-600/30 rounded-2xl">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm">💼</span>
+                          <span className="text-sm font-medium text-slate-700 dark:text-slate-300">営業日</span>
+                        </div>
+                        <div className="text-xl font-bold text-slate-800 dark:text-slate-200">
+                          {business}日
+                        </div>
                       </div>
                     </div>
-                    
-                    <div className="flex items-center justify-between p-4 bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-700/30 dark:to-slate-600/30 rounded-2xl">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm">💼</span>
-                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">営業日</span>
-                      </div>
-                      <div className="text-xl font-bold text-slate-800 dark:text-slate-200">
-                        {business}日
-                      </div>
-                    </div>
-                  </div>
+                  )}
                 </div>
               </div>
             );


### PR DESCRIPTION
## Summary
- add toggle for simple date-only display mode
- document simple mode

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5abcd963c832ebe854edac1c258ff