### PR TITLE
feat: persist dark mode in URL

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 .env
 .DS_Store
 .idea
+pnpm-lock.yaml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,9 +96,13 @@ function businessDaysBetween(start: Temporal.PlainDate, end: Temporal.PlainDate)
 export default function App() {
   const customTargetSectionRef = useRef<HTMLDivElement>(null);
   const [now, setNow] = useState(Temporal.Now.zonedDateTimeISO(tz));
-  const [dark, setDark] = useState(
-    () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-  );
+  const [dark, setDark] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    const param = params.get('dark');
+    if (param === 'true') return true;
+    if (param === 'false') return false;
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
   const [simple, setSimple] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('simple') === 'true';
@@ -126,6 +130,9 @@ export default function App() {
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark);
+    const url = new URL(window.location.href);
+    url.searchParams.set('dark', dark ? 'true' : 'false');
+    window.history.replaceState({}, '', url.toString());
   }, [dark]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- preserve dark mode state via `dark` URL query parameter
- exclude `pnpm-lock.yaml` from Prettier to avoid formatting noise

## Testing
- `pnpm run lint`
- `pnpm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a7267f5a70832eaf6f9c7acf49df3e