### PR TITLE
refactor: remove unused state setter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,13 +107,12 @@ export default function App() {
     const params = new URLSearchParams(window.location.search);
     return params.get('simple') === 'true';
   });
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [targetFromUrl, setTargetFromUrl] = useState(() => {
+  const [targetFromUrl] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     const name = params.get('name');
     const date = params.get('date');
     if (name && date) {
-      return { label: name, date: date };
+      return { label: name, date };
     }
     return null;
   });


### PR DESCRIPTION
## Summary
- avoid eslint-disable by removing unused state setter in App

## Testing
- `pnpm run lint` *(fails: React package missing)*
- `pnpm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a731e60758832e8931625e32b9c541