### PR TITLE
chore: add Playwright E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,23 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: npx playwright install --with-deps
+      - run: pnpm run test:e2e

--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('トップページに月末のカウンターが表示される', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('月末')).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "deploy": "gh-pages -d dist",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
@@ -27,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.41.0",
     "@vitejs/plugin-react": "^5.0.1",
+    "@playwright/test": "^1.47.0",
     "eslint": "^9.34.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  fullyParallel: true,
+  webServer: {
+    command: 'pnpm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright and basic end-to-end test
- run Playwright tests in GitHub Actions

## Testing
- `pnpm run format:check` *(fails: pnpm: command not found)*
- `pnpm run lint` *(fails: pnpm: command not found)*
- `pnpm run test:e2e` *(fails: pnpm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5342967c832eb52895a400836335